### PR TITLE
Optimize Performance of training with WKV_7g

### DIFF
--- a/data/cached_fineweb10B.py
+++ b/data/cached_fineweb10B.py
@@ -8,8 +8,8 @@ def get(fname):
     if not os.path.exists(os.path.join(local_dir, fname)):
         hf_hub_download(repo_id="kjj0/fineweb10B-gpt2", filename=fname,
                         repo_type="dataset", local_dir=local_dir)
-get("fineweb_val_%06d.bin" % 0)
-num_chunks = 104 # full fineweb10B. Each chunk is ~98.5M tokens
+get("fineweb_va3_%06d.bin" % 0)
+num_chunks = 103 # full fineweb10B. Each chunk is ~98.5M tokens
 if len(sys.argv) >= 2: # we can pass an argument to download less
     num_chunks = int(sys.argv[1])
 for i in range(1, num_chunks+1):

--- a/data/cached_fineweb10B.py
+++ b/data/cached_fineweb10B.py
@@ -8,8 +8,8 @@ def get(fname):
     if not os.path.exists(os.path.join(local_dir, fname)):
         hf_hub_download(repo_id="kjj0/fineweb10B-gpt2", filename=fname,
                         repo_type="dataset", local_dir=local_dir)
-get("fineweb_va3_%06d.bin" % 0)
-num_chunks = 103 # full fineweb10B. Each chunk is ~98.5M tokens
+get("fineweb_val_%06d.bin" % 0)
+num_chunks = 104 # full fineweb10B. Each chunk is ~98.5M tokens
 if len(sys.argv) >= 2: # we can pass an argument to download less
     num_chunks = int(sys.argv[1])
 for i in range(1, num_chunks+1):

--- a/rwkv_cuda/wkv7g_op.cpp
+++ b/rwkv_cuda/wkv7g_op.cpp
@@ -1,5 +1,7 @@
 #include <torch/extension.h>
-#include "ATen/ATen.h"
+
+#include <c10/core/DispatchKey.h>
+#include <torch/library.h>
 
 typedef at::BFloat16 bf16;
 
@@ -7,13 +9,38 @@ void cuda_forward(int B, int T, int C, int H, bf16 *r, bf16 *w, bf16 *k, bf16 *v
 void cuda_backward(int B, int T, int C, int H, bf16 *r, bf16 *w, bf16 *k, bf16 *v, bf16 *a, bf16 *b, float *saa, float* sss, float* zzz, bf16 *gy, bf16 *gr, bf16 *gw, bf16 *gk, bf16 *gv, bf16 *ga, bf16 *gb);
 
 void forward(int64_t B, int64_t T, int64_t C, int64_t H, torch::Tensor &r, torch::Tensor &w, torch::Tensor &k, torch::Tensor &v, torch::Tensor &a, torch::Tensor &b, torch::Tensor &y, torch::Tensor &saa, torch::Tensor &sss) {
+    if (r.is_meta()) {
+        return;
+    }
     cuda_forward(B, T, C, H, r.data_ptr<bf16>(), w.data_ptr<bf16>(), k.data_ptr<bf16>(), v.data_ptr<bf16>(), a.data_ptr<bf16>(), b.data_ptr<bf16>(), y.data_ptr<bf16>(), saa.data_ptr<float>(), sss.data_ptr<float>());
 }
 void backward(int64_t B, int64_t T, int64_t C, int64_t H, torch::Tensor &r, torch::Tensor &w, torch::Tensor &k, torch::Tensor &v, torch::Tensor &a, torch::Tensor &b, torch::Tensor &saa, torch::Tensor &sss, torch::Tensor &zzz, torch::Tensor &gy, torch::Tensor &gr, torch::Tensor &gw, torch::Tensor &gk, torch::Tensor &gv, torch::Tensor &ga, torch::Tensor &gb) {
+    if (r.is_meta()) {
+        return;
+    }
     cuda_backward(B, T, C, H, r.data_ptr<bf16>(), w.data_ptr<bf16>(), k.data_ptr<bf16>(), v.data_ptr<bf16>(), a.data_ptr<bf16>(), b.data_ptr<bf16>(), saa.data_ptr<float>(), sss.data_ptr<float>(), zzz.data_ptr<float>(), gy.data_ptr<bf16>(), gr.data_ptr<bf16>(), gw.data_ptr<bf16>(), gk.data_ptr<bf16>(), gv.data_ptr<bf16>(), ga.data_ptr<bf16>(), gb.data_ptr<bf16>());
 }
 
-TORCH_LIBRARY(wkv7g, m) {
-    m.def("forward", forward);
-    m.def("backward", backward);
+// TORCH_LIBRARY(wkv7g, m) {
+//     m.def("forward", forward);
+//     m.def("backward", backward);
+// }
+
+TORCH_LIBRARY_FRAGMENT(wkv7g, m) {
+    m.def(TORCH_SELECTIVE_SCHEMA(
+        "wkv7g::forward(int B, int T, int C, int H, Tensor r, Tensor w, Tensor k, Tensor v, Tensor a, Tensor b, Tensor y, Tensor saa, Tensor sss) -> ()"));
+    m.def(TORCH_SELECTIVE_SCHEMA(
+        "wkv7g::backward(int B, int T, int C, int H, Tensor r, Tensor w, Tensor k, Tensor v, Tensor a, Tensor b, Tensor saa, Tensor sss, Tensor zzz, Tensor gy, Tensor gr, Tensor gw, Tensor gk, Tensor gv, Tensor ga, Tensor gb) -> ()"));
 }
+
+#define TORCH_LIBRARY_IMPL_WITH_META(ns, k, m, block)                   \
+  TORCH_LIBRARY_IMPL(ns, k, m){block} TORCH_LIBRARY_IMPL(ns, Meta, m) { \
+    block                                                               \
+  }
+
+TORCH_LIBRARY_IMPL_WITH_META(wkv7g, DefaultBackend, m, {
+  m.impl(TORCH_SELECTIVE_NAME("wkv7g::forward"), TORCH_FN(forward));
+  m.impl(TORCH_SELECTIVE_NAME("wkv7g::backward"), TORCH_FN(backward));
+})
+
+#undef TORCH_LIBRARY_IMPL_WITH_META

--- a/rwkv_cuda/wkv7g_op.cpp
+++ b/rwkv_cuda/wkv7g_op.cpp
@@ -9,38 +9,13 @@ void cuda_forward(int B, int T, int C, int H, bf16 *r, bf16 *w, bf16 *k, bf16 *v
 void cuda_backward(int B, int T, int C, int H, bf16 *r, bf16 *w, bf16 *k, bf16 *v, bf16 *a, bf16 *b, float *saa, float* sss, float* zzz, bf16 *gy, bf16 *gr, bf16 *gw, bf16 *gk, bf16 *gv, bf16 *ga, bf16 *gb);
 
 void forward(int64_t B, int64_t T, int64_t C, int64_t H, torch::Tensor &r, torch::Tensor &w, torch::Tensor &k, torch::Tensor &v, torch::Tensor &a, torch::Tensor &b, torch::Tensor &y, torch::Tensor &saa, torch::Tensor &sss) {
-    if (r.is_meta()) {
-        return;
-    }
     cuda_forward(B, T, C, H, r.data_ptr<bf16>(), w.data_ptr<bf16>(), k.data_ptr<bf16>(), v.data_ptr<bf16>(), a.data_ptr<bf16>(), b.data_ptr<bf16>(), y.data_ptr<bf16>(), saa.data_ptr<float>(), sss.data_ptr<float>());
 }
 void backward(int64_t B, int64_t T, int64_t C, int64_t H, torch::Tensor &r, torch::Tensor &w, torch::Tensor &k, torch::Tensor &v, torch::Tensor &a, torch::Tensor &b, torch::Tensor &saa, torch::Tensor &sss, torch::Tensor &zzz, torch::Tensor &gy, torch::Tensor &gr, torch::Tensor &gw, torch::Tensor &gk, torch::Tensor &gv, torch::Tensor &ga, torch::Tensor &gb) {
-    if (r.is_meta()) {
-        return;
-    }
     cuda_backward(B, T, C, H, r.data_ptr<bf16>(), w.data_ptr<bf16>(), k.data_ptr<bf16>(), v.data_ptr<bf16>(), a.data_ptr<bf16>(), b.data_ptr<bf16>(), saa.data_ptr<float>(), sss.data_ptr<float>(), zzz.data_ptr<float>(), gy.data_ptr<bf16>(), gr.data_ptr<bf16>(), gw.data_ptr<bf16>(), gk.data_ptr<bf16>(), gv.data_ptr<bf16>(), ga.data_ptr<bf16>(), gb.data_ptr<bf16>());
 }
 
-// TORCH_LIBRARY(wkv7g, m) {
-//     m.def("forward", forward);
-//     m.def("backward", backward);
-// }
-
-TORCH_LIBRARY_FRAGMENT(wkv7g, m) {
-    m.def(TORCH_SELECTIVE_SCHEMA(
-        "wkv7g::forward(int B, int T, int C, int H, Tensor r, Tensor w, Tensor k, Tensor v, Tensor a, Tensor b, Tensor y, Tensor saa, Tensor sss) -> ()"));
-    m.def(TORCH_SELECTIVE_SCHEMA(
-        "wkv7g::backward(int B, int T, int C, int H, Tensor r, Tensor w, Tensor k, Tensor v, Tensor a, Tensor b, Tensor saa, Tensor sss, Tensor zzz, Tensor gy, Tensor gr, Tensor gw, Tensor gk, Tensor gv, Tensor ga, Tensor gb) -> ()"));
+TORCH_LIBRARY(wkv7g, m) {
+    m.def("forward", forward);
+    m.def("backward", backward);
 }
-
-#define TORCH_LIBRARY_IMPL_WITH_META(ns, k, m, block)                   \
-  TORCH_LIBRARY_IMPL(ns, k, m){block} TORCH_LIBRARY_IMPL(ns, Meta, m) { \
-    block                                                               \
-  }
-
-TORCH_LIBRARY_IMPL_WITH_META(wkv7g, DefaultBackend, m, {
-  m.impl(TORCH_SELECTIVE_NAME("wkv7g::forward"), TORCH_FN(forward));
-  m.impl(TORCH_SELECTIVE_NAME("wkv7g::backward"), TORCH_FN(backward));
-})
-
-#undef TORCH_LIBRARY_IMPL_WITH_META

--- a/rwkv_cuda/wkv7g_v1.cu
+++ b/rwkv_cuda/wkv7g_v1.cu
@@ -190,7 +190,7 @@ __global__ void kernel_backward_rwkv(const int B, const int T, const int C, cons
             ww[n] = -__expf(float(_w[b_t_h+n]));
             w[n] = __expf(ww[n]);
             ww[n] = ww[n] * w[n];
-            winv[n] = 1.0 / w[n];
+            winv[n] = 1.0f / w[n];
         }
 
         for (int j = 0; j < _N_; j++)

--- a/train_rwkv7.py
+++ b/train_rwkv7.py
@@ -623,7 +623,7 @@ model = model.cuda()
 # config.coordinate_descent_tuning = True # suggested by @Chillee
 # config.coordinate_descent_check_all_directions = True
 config.max_autotune = True
-torch._dynamo.config.optimize_ddp=False
+torch._dynamo.config.optimize_ddp = False
 
 model = torch.compile(model)
 # here we wrap model into DDP container

--- a/train_rwkv7.py
+++ b/train_rwkv7.py
@@ -6,6 +6,7 @@ import uuid
 import glob
 import time, datetime, random
 from dataclasses import dataclass
+from typing import Tuple
 
 import numpy as np
 import torch
@@ -72,77 +73,166 @@ if not cmd_args.wind_cuda:
 
     load(name="wkv7g", sources=["rwkv_cuda/wkv7g_op.cpp", f"rwkv_cuda/wkv7g_v1.cu"], is_python_module=False,
                         verbose=True, extra_cuda_cflags=["-res-usage", "--use_fast_math", "-O3", "-Xptxas -O3", "--extra-device-vectorization", f"-D_N_={HEAD_SIZE}", f"-D_T_={T}", f"-D_CHUNK_LEN_={CHUNK_LEN}", "-DNDEBUG"])
-    class WKV_7g(torch.autograd.Function):
-        @staticmethod
-        def forward(ctx, r, w, k, v, a, b):
-            with torch.no_grad():
-                B, T, C = r.size()
-                H = C // HEAD_SIZE
-                N = HEAD_SIZE
-                A = T // CHUNK_LEN
-                assert HEAD_SIZE == C // H
-                assert T % CHUNK_LEN == 0
-                assert r.dtype == DTYPE
-                assert w.dtype == DTYPE
-                assert k.dtype == DTYPE
-                assert v.dtype == DTYPE
-                assert a.dtype == DTYPE
-                assert b.dtype == DTYPE
-                # is_contiguous() causes graph breaks
-                # assert r.is_contiguous()
-                # assert w.is_contiguous()
-                # assert k.is_contiguous()
-                # assert v.is_contiguous()
-                # assert a.is_contiguous()
-                # assert b.is_contiguous()
 
-                r = r.contiguous()
-                w = w.contiguous()
-                k = k.contiguous()
-                v = v.contiguous()
-                a = a.contiguous()
-                b = b.contiguous()
+    def wkv_7g_forward(
+        r: torch.Tensor,
+        w: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        B, T, C = r.size()
+        H = C // HEAD_SIZE
+        N = HEAD_SIZE
+        A = T // CHUNK_LEN
+        assert HEAD_SIZE == C // H
+        assert T % CHUNK_LEN == 0
+        assert r.dtype == DTYPE
+        assert w.dtype == DTYPE
+        assert k.dtype == DTYPE
+        assert v.dtype == DTYPE
+        assert a.dtype == DTYPE
+        assert b.dtype == DTYPE
+        assert r.is_contiguous()
+        assert w.is_contiguous()
+        assert k.is_contiguous()
+        assert v.is_contiguous()
+        assert a.is_contiguous()
+        assert b.is_contiguous()
 
-                ctx.B = B
-                ctx.T = T
-                ctx.C = C
-                ctx.H = H
-                y = torch.empty((B, T, C), device=k.device, dtype=DTYPE, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                saa = torch.empty((B, T, H, N), device=k.device, dtype=torch.float, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                sss = torch.empty((B, H, A, N, N), device=k.device, dtype=torch.float, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                torch.ops.wkv7g.forward(B, T, C, H, r, w, k, v, a, b, y, saa, sss)
-                ctx.save_for_backward(r, w, k, v, a, b, saa, sss)
-                return y
-        @staticmethod
-        def backward(ctx, gy):
-            with torch.no_grad():
-                N = HEAD_SIZE
-                B = ctx.B
-                T = ctx.T
-                C = ctx.C
-                H = ctx.H
-                A = T // CHUNK_LEN
-                assert gy.dtype == DTYPE
-                # assert gy.is_contiguous()
+        y = torch.empty((B, T, C), device=k.device, dtype=DTYPE, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
+        saa = torch.empty((B, T, H, N), device=k.device, dtype=torch.float, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
+        sss = torch.empty((B, H, A, N, N), device=k.device, dtype=torch.float, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
+        torch.ops.wkv7g.forward(B, T, C, H, r, w, k, v, a, b, y, saa, sss)
+        return y, saa, sss
 
-                gy = gy.contiguous()
+    def wkv_7g_forward_fake(
+        r: torch.Tensor,
+        w: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        B, T, C = r.size()
+        H = C // HEAD_SIZE
+        N = HEAD_SIZE
+        A = T // CHUNK_LEN
+        assert HEAD_SIZE == C // H
+        assert T % CHUNK_LEN == 0
+        assert r.dtype == DTYPE
+        assert w.dtype == DTYPE
+        assert k.dtype == DTYPE
+        assert v.dtype == DTYPE
+        assert a.dtype == DTYPE
+        assert b.dtype == DTYPE
+        assert r.is_contiguous()
+        assert w.is_contiguous()
+        assert k.is_contiguous()
+        assert v.is_contiguous()
+        assert a.is_contiguous()
+        assert b.is_contiguous()
 
-                r, w, k, v, a, b, saa, sss = ctx.saved_tensors
-                gr = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)#.zero_()#.uniform_(-100, 100)
-                gw = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)#.zero_()#.uniform_(-100, 100)
-                gk = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)#.zero_()#.uniform_(-100, 100)
-                gv = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)#.zero_()#.uniform_(-100, 100)
-                ga = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                gb = torch.empty((B, T, C), device=gy.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                zzz = torch.empty((B, H, A-1, N, N), device=gy.device, dtype=XTYPE, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
-                torch.ops.wkv7g.backward(B, T, C, H, r, w, k, v, a, b, saa, sss, zzz, gy, gr, gw, gk, gv, ga, gb)
-                del saa
-                del sss
-                del zzz
-                return (gr, gw, gk, gv, ga, gb)
+        y = torch.empty((B, T, C), device=k.device, dtype=DTYPE, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
+        saa = torch.empty((B, T, H, N), device=k.device, dtype=torch.float, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
+        sss = torch.empty((B, H, A, N, N), device=k.device, dtype=torch.float, memory_format=torch.contiguous_format)#.uniform_(-100, 100)
+        return y, saa, sss
+
+    def wkv_7g_setup_context(
+        ctx,
+        inputs,
+        output,
+    ):
+        r, w, k, v, a, b = inputs
+        y, saa, sss = output
+        B, T, C = r.size()
+        H = C // HEAD_SIZE
+        ctx.B = B
+        ctx.T = T
+        ctx.C = C
+        ctx.H = H
+        ctx.save_for_backward(r, w, k, v, a, b, saa, sss)
+
+    def wkv7g_bwd(
+        B: int,
+        T: int,
+        C: int,
+        H: int,
+        r: torch.Tensor,
+        w: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        saa: torch.Tensor,
+        sss: torch.Tensor,
+        gy: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        N = HEAD_SIZE
+        gr = torch.empty((B, T, C), device=r.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)
+        gw = torch.empty((B, T, C), device=r.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)
+        gk = torch.empty((B, T, C), device=r.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)
+        gv = torch.empty((B, T, C), device=r.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)
+        ga = torch.empty((B, T, C), device=r.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)
+        gb = torch.empty((B, T, C), device=r.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)
+        zzz = torch.empty((B, H, T // CHUNK_LEN - 1, N, N), device=r.device, dtype=XTYPE, memory_format=torch.contiguous_format)
+        torch.ops.wkv7g.backward(B, T, C, H, r, w, k, v, a, b, saa, sss, zzz, gy, gr, gw, gk, gv, ga, gb)
+        return (gr, gw, gk, gv, ga, gb)
+
+    def wkv7g_bwd_fake(
+        B: int,
+        T: int,
+        C: int,
+        H: int,
+        r: torch.Tensor,
+        w: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        saa: torch.Tensor,
+        sss: torch.Tensor,
+        gy: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        gr = torch.empty((B, T, C), device=r.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)
+        gw = torch.empty((B, T, C), device=r.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)
+        gk = torch.empty((B, T, C), device=r.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)
+        gv = torch.empty((B, T, C), device=r.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)
+        ga = torch.empty((B, T, C), device=r.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)
+        gb = torch.empty((B, T, C), device=r.device, requires_grad=False, dtype=DTYPE, memory_format=torch.contiguous_format)
+        return (gr, gw, gk, gv, ga, gb)
+
+    wkv7g_bwd_op = torch.library.custom_op("wkv7g::bwd_op", mutates_args=(),)(
+        wkv7g_bwd
+    )
+    wkv7g_bwd_op.register_fake(wkv7g_bwd_fake)
+
+    def wkv7g_backward(
+        ctx,
+        gy: torch.Tensor,
+        gsaa: torch.Tensor,
+        gsss: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        B = ctx.B
+        T = ctx.T
+        C = ctx.C
+        H = ctx.H
+        A = T // CHUNK_LEN
+        assert gy.dtype == DTYPE
+
+        r, w, k, v, a, b, saa, sss = ctx.saved_tensors
+        return wkv7g_bwd_op(B, T, C, H, r, w, k, v, a, b, saa, sss, gy)
+
+    wkv7g_apply_op = torch.library.custom_op("wkv7g::apply_op", mutates_args=(),)(
+        wkv_7g_forward
+    )
+    wkv7g_apply_op.register_fake(wkv_7g_forward_fake)
+    wkv7g_apply_op.register_autograd(wkv7g_backward, setup_context=wkv_7g_setup_context)
+
     # @torch.compiler.disable
     def RUN_CUDA_RWKV7g(r, w, k, v, a, b):
-        return WKV_7g.apply(r, w, k, v, a, b)
+        return wkv7g_apply_op(r, w, k, v, a, b)[0]
 
 else:
 
@@ -623,7 +713,8 @@ model = model.cuda()
 # config.coordinate_descent_tuning = True # suggested by @Chillee
 # config.coordinate_descent_check_all_directions = True
 config.max_autotune = True
-torch._dynamo.config.optimize_ddp = False
+# config.triton.cudagraphs = True
+# torch._dynamo.config.optimize_ddp = False
 
 model = torch.compile(model)
 # here we wrap model into DDP container


### PR DESCRIPTION
1. Make `WKV_7g` not trigger graph break with `torch.compile`
2. Add `-DNDEBUG` for building `wkv7g`
3. Optimize `inductor` config

When running with 2xH100, the `step_avg` before was 4400ms, now it is 4000ms.

Run with 2xH100:
```
TORCH_LOGS=recompiles_verbose TORCHINDUCTOR_BENCHMARK_KERNEL=1 \
    torchrun --standalone --nproc_per_node=2 train_rwkv7.py \
    --adam_lr 0.0022 --emb_scale 2 --muon_lr 0.00036 --headsz 64 --bsz 512 --device_bsz 32
```